### PR TITLE
solve issue of logger

### DIFF
--- a/backend/app/logger.py
+++ b/backend/app/logger.py
@@ -1,7 +1,10 @@
 import os
 import sys
 import logging
-from logging.handlers import TimedRotatingFileHandler
+from logging.handlers import TimedRotatingFileHandler, QueueHandler, QueueListener
+
+import atexit
+from queue import Queue
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 LOG_DIR = os.path.join(BASE_DIR, 'logs')


### PR DESCRIPTION
## Summary by Sourcery

Improve logger reliability by switching to asynchronous queue-based handlers, ensuring log directory creation, and gracefully shutting down the logging listener on exit

Enhancements:
- Add QueueHandler and QueueListener for asynchronous dispatch to the TimedRotatingFileHandler
- Automatically create the logs directory if it does not exist
- Register listener.stop with atexit to gracefully stop the logging listener at program exit