### PR TITLE
add makefile for the single command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+DOCKER_COMPOSE=docker-compose
+PYTHON=python
+PIP=pip
+DOCKER=docker
+
+INFO = @echo [INFO]
+
+.PHONY: help build up down logs test lint format install
+
+format:
+	$(INFO) "Formatting code with black..."
+	$(PYTHON) -m black .

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -5,12 +5,15 @@ from starlette.config import Config
 
 config = Config("app/.env")
 
+
 class Settings(BaseSettings):
     VERSION: str = config("VERSION", default="1.0.0")
+
 
 @lru_cache()
 def get_settings() -> Settings:
     settings = Settings()
     return settings
+
 
 settings = get_settings()

--- a/backend/app/logger.py
+++ b/backend/app/logger.py
@@ -7,15 +7,16 @@ import atexit
 from queue import Queue
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-LOG_DIR = os.path.join(BASE_DIR, 'logs')
+LOG_DIR = os.path.join(BASE_DIR, "logs")
 os.makedirs(LOG_DIR, exist_ok=True)
 
-LOG_FILE = os.path.join(LOG_DIR, 'app.log')
+LOG_FILE = os.path.join(LOG_DIR, "app.log")
 
 ROOT_LOG_LEVEL = logging.WARNING
 PROJECT_LOGGER_NAME = "app"
 
 DATE_FMT = "%Y-%m-%d %H:%M:%S"
+
 
 def _rel(path: str) -> str:
     """Return *repo-relative* path or just the basename if outside repo."""
@@ -37,6 +38,7 @@ def _record_factory(*a, **kw):  # type: ignore[override]
 
 logging.setLogRecordFactory(_record_factory)
 
+
 class PathAwareFormatter(logging.Formatter):
     def __init__(self, fmt_src: str, fmt_no_src: str, **kw):
         super().__init__(fmt_src, **kw)
@@ -50,6 +52,7 @@ class PathAwareFormatter(logging.Formatter):
             return super().format(record)
         finally:
             self._style._fmt = orig
+
 
 # Templates
 FILE_FMT_SRC = "%(asctime)s | %(levelname)-8s | %(relativepath)s:%(lineno)d | %(message)s"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,10 +7,14 @@ from app.core.config import settings
 
 app = FastAPI()
 
+
 @app.get("/api/health", summary="Health Check", tags="System")
 async def health_check():
     logger.info("Health check endpoint called")
-    return JSONResponse(status_code=status.HTTP_200_OK, content={"message":"Healthy","status":True, "version":settings.VERSION})
+    return JSONResponse(
+        status_code=status.HTTP_200_OK, content={"message": "Healthy", "status": True, "version": settings.VERSION}
+    )
+
 
 if __name__ == "__main__":
     run(app, host="0.0.0.0", port=8000, log_config=None)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,6 @@
 annotated-types==0.7.0
 anyio==4.10.0
+black==25.1.0
 boto3==1.40.11
 botocore==1.40.11
 click==8.2.1
@@ -7,6 +8,10 @@ fastapi==0.116.1
 h11==0.16.0
 idna==3.10
 jmespath==1.0.1
+mypy_extensions==1.1.0
+packaging==25.0
+pathspec==0.12.1
+platformdirs==4.3.8
 pydantic==2.11.7
 pydantic-settings==2.10.1
 pydantic_core==2.33.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+version = "v1.0.2"
+
+[tool.black]
+line-length = 127
+exclude = '''
+/(
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | env
+  | venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''
+
+[tool.bandit]
+exclude_dirs = ["*/env/*"]


### PR DESCRIPTION
- install black for code format using make
- update requirement.txt file
- code format by black

## Summary by Sourcery

Add a Makefile to streamline development workflows and enforce consistent code formatting with Black.

New Features:
- Add Makefile with a `format` target for running Black in a single command

Enhancements:
- Introduce pyproject.toml to configure Black and Bandit
- Update requirements.txt to include Black and its dependencies

Chores:
- Reformat the codebase with Black for consistent styling (quotes, whitespace, line breaks)