### PR TITLE
Fix unhashable type error in get_all_products API

### DIFF
--- a/backend/app/api/v1/restapi/products.py
+++ b/backend/app/api/v1/restapi/products.py
@@ -62,7 +62,7 @@ async def get_all_products(
     try:
         skip = (page - 1) * limit
 
-        pipeline = [{"$facet": {"metadata": [{"$count": "total"}], "data": {{"$skip": skip}, {"$limit": limit}}}}]
+        pipeline = [{"$facet": {"metadata": [{"$count": "total"}], "data": [{"$skip": skip}, {"$limit": limit}]}}]
 
         result = await products_collection.aggregate(pipeline).to_list(length=None)
 


### PR DESCRIPTION
- Replaced sets with lists in MongoDB  pipeline
- Corrected  field to use [{'': skip}, {'': limit}] instead of {{'': skip}, {'': limit}}
- Prevents unhashable type: 'dict' runtime error during product fetching

## Summary by Sourcery

Bug Fixes:
- Prevent unhashable type 'dict' error by replacing set with list in the MongoDB aggregation pipeline of get_all_products API