### PR TITLE
resolve qty error to the create order endpoint

### DIFF
--- a/backend/app/api/v1/restapi/orders.py
+++ b/backend/app/api/v1/restapi/orders.py
@@ -21,7 +21,8 @@ async def order_place(
     user_payload: dict = Depends(auth_services.get_current_user),
 ):
     try:
-        user_id = user_payload.get("_id", "")
+        logger.debug(f"user_payload: {user_payload}")
+        user_id = user_payload.get("sub", "")
 
         if not user_id:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized user")
@@ -47,7 +48,7 @@ async def order_place(
                 {
                     "product_id": str(product["_id"]),
                     "name": product.get("name"),
-                    "quantity": item.quantity,
+                    "quantity": item.qty,
                     "price": product.get("price"),
                 }
             )


### PR DESCRIPTION
## Summary by Sourcery

Resolve quantity mismatch and unauthorized user lookup in the order creation endpoint

Bug Fixes:
- Extract user_id from the token’s 'sub' claim instead of '_id' and add debug logging for user payload
- Use the correct 'qty' field on order items to populate the quantity in the create order response