### PR TITLE
Feat/graphql implementation

### DIFF
--- a/backend/app/schemas/graphql_orders.py
+++ b/backend/app/schemas/graphql_orders.py
@@ -1,0 +1,21 @@
+import strawberry
+from typing import List
+
+from pydantic import Field
+
+
+
+@strawberry.type
+class Order:
+    id: str = Field(..., description="Unique identifier for the order")
+    name: str = Field(..., description="Name of the product")
+    qty: int = Field(..., description="Quantity of the product ordered", ge=1, example=2)
+    total_price: float = Field(..., description="Total price of this order", ge=0)
+
+@strawberry.type
+class UserOrderTypes:
+    id: str = Field(..., description="User id of the product")
+    name: str = Field(..., description="Name of the user")
+    shapping_address: str = Field(..., description="Shipping address of the user")
+    status: str = Field(..., description="Status of the user")
+    orders: List[Order] = Field(..., description="User order details")

--- a/backend/app/schemas/graphql_orders.py
+++ b/backend/app/schemas/graphql_orders.py
@@ -9,7 +9,7 @@ from pydantic import Field
 class Order:
     id: str = Field(..., description="Unique identifier for the order")
     name: str = Field(..., description="Name of the product")
-    qty: int = Field(..., description="Quantity of the product ordered", ge=1, example=2)
+    qty: int = Field(..., description="Quantity of the product ordered", ge=1)
     total_price: float = Field(..., description="Total price of this order", ge=0)
 
 @strawberry.type

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,6 +10,7 @@ dnspython==2.7.0
 ecdsa==0.19.1
 email_validator==2.2.0
 fastapi==0.116.1
+graphql-core==3.2.6
 h11==0.16.0
 httpcore==1.0.9
 httpx==0.28.1
@@ -17,6 +18,7 @@ idna==3.10
 itsdangerous==2.2.0
 Jinja2==3.1.6
 jmespath==1.0.1
+lia-web==0.2.3
 MarkupSafe==3.0.2
 motor==3.7.1
 mypy_extensions==1.1.0
@@ -40,6 +42,7 @@ setuptools==78.1.1
 six==1.17.0
 sniffio==1.3.1
 starlette==0.47.2
+strawberry-graphql==0.282.0
 typing-inspection==0.4.1
 typing_extensions==4.14.1
 urllib3==2.5.0


### PR DESCRIPTION
## Summary by Sourcery

Implement basic GraphQL support for orders by adding necessary dependencies and defining Order and UserOrderTypes schemas

New Features:
- Add GraphQL schemas for orders with Order and UserOrderTypes types using Strawberry

Build:
- Add graphql-core, strawberry-graphql, and lia-web dependencies to backend requirements